### PR TITLE
Added a resetBackground function that styles all date div's

### DIFF
--- a/source/assets/scripts/dailylog.js
+++ b/source/assets/scripts/dailylog.js
@@ -57,6 +57,8 @@ document.addEventListener('DOMContentLoaded', function () {
             }
 
             dateDiv.addEventListener("click", function() { 
+                // Reset background of all dates
+                resetBackground(); 
                 selectDate(dateStr); 
                 // Set the background and border radius of the date that has just been clicked 
                 dateDiv.setAttribute('style','background-color: #674832; border-radius: 10%;');
@@ -89,6 +91,23 @@ document.addEventListener('DOMContentLoaded', function () {
         currentDate = new Date();
         updateCalendar(); 
         selectDate(dateToString(currentDate));
+    }
+
+    /**
+     * Resets the background of all date div's to original styling
+     * Resets background for today's date to intended styling 
+     */
+    function resetBackground() { 
+        let dateDivs = document.querySelectorAll('.date'); 
+        for (let i = 0; i < dateDivs.length; i++) { 
+            let dateDiv = dateDivs[i]; 
+            dateDiv.setAttribute('style',' background-color: #d1a689;');
+        } 
+        let today = document.querySelector('.date.today'); 
+        if (today) { 
+            today.setAttribute('style', 'background-color: #468c7a; color: #F4EDE3; border-radius: 50%;font-weight: bold;');
+        }
+
     }
 
     // Initialize the calendar


### PR DESCRIPTION
## Pull request summary:
Added a resetBackground() function that resets the styling of all date div's

## Type of change (bug, feature, design, logistics, etc):
Design

## How has this been tested (if applicable):
It works for current, previous, and future months. 

## Checklist:
- [x] I have performed a self-review of my own code
- [x] I have tested that my changes work (locally and via unit testing)
- [x] I have assigned atleast 2 reviewers to look at and review my code quality
- [x] Documentation has been updated
- [x] Code follows style guidelines
